### PR TITLE
Add WHOOP to the fitness dashboard

### DIFF
--- a/components/pages/fitness/fitness-dashboard.tsx
+++ b/components/pages/fitness/fitness-dashboard.tsx
@@ -3,7 +3,14 @@ import { useEffect, useMemo, useState } from 'react';
 import { Dumbbell } from 'lucide-react';
 import clsx from 'clsx';
 
-import type { FitnessActivity, FitnessSleepRecord, FitnessRecoveryRecord } from '@/pages/fitness';
+import type {
+  FitnessActivity,
+  FitnessSleepRecord,
+  FitnessRecoveryRecord,
+  FitnessWhoopRecovery,
+  FitnessWhoopSleep,
+  FitnessWhoopCycle,
+} from '@/pages/fitness';
 import type { StressDayRecord } from '@/pages/api/fitness/stress-data';
 import FitnessHeatmap from './fitness-heatmap';
 import FitnessAreaChart from './fitness-area-chart';
@@ -15,11 +22,17 @@ import FitnessCoaching from './fitness-coaching';
 import FitnessSleep from './fitness-sleep';
 import FitnessStressHeatmap from './fitness-stress-heatmap';
 import FitnessTrends from './fitness-trends';
+import WhoopRecoveryView from './fitness-whoop-recovery';
+import WhoopSleepView from './fitness-whoop-sleep';
+import WhoopStrainView from './fitness-whoop-strain';
+import WhoopTrendsView from './fitness-whoop-trends';
 
 type Unit = 'km' | 'mi';
-type Source = 'all' | 'strava' | 'garmin';
+type Source = 'all' | 'strava' | 'garmin' | 'whoop';
 type PerfTab = 'insights' | 'best-efforts' | 'coaching';
-type RecoveryTab = 'sleep' | 'stress' | 'trends';
+type RecoverySource = 'garmin' | 'whoop';
+type GarminRecoveryTab = 'sleep' | 'stress' | 'trends';
+type WhoopRecoveryTab = 'recovery' | 'sleep' | 'strain' | 'trends';
 type TrainingTab = 'heatmap' | 'distance' | 'sports';
 
 const SPORT_LABELS: Record<string, string> = {
@@ -180,13 +193,18 @@ export default function FitnessDashboard() {
   const [sleepRecords, setSleepRecords] = useState<FitnessSleepRecord[]>([]);
   const [recoveryRecords, setRecoveryRecords] = useState<FitnessRecoveryRecord[]>([]);
   const [stressRecords, setStressRecords] = useState<StressDayRecord[]>([]);
+  const [whoopRecovery, setWhoopRecovery] = useState<FitnessWhoopRecovery[]>([]);
+  const [whoopSleep, setWhoopSleep] = useState<FitnessWhoopSleep[]>([]);
+  const [whoopCycles, setWhoopCycles] = useState<FitnessWhoopCycle[]>([]);
   const [loading, setLoading] = useState(true);
   const [unit, setUnit] = useState<Unit>('km');
   const [source, setSource] = useState<Source>('all');
   const [sportType, setSportType] = useState('all');
 
   const [perfTab, setPerfTab] = useState<PerfTab>('insights');
-  const [recoveryTab, setRecoveryTab] = useState<RecoveryTab>('sleep');
+  const [recoverySource, setRecoverySource] = useState<RecoverySource>('garmin');
+  const [garminTab, setGarminTab] = useState<GarminRecoveryTab>('sleep');
+  const [whoopTab, setWhoopTab] = useState<WhoopRecoveryTab>('recovery');
   const [trainingTab, setTrainingTab] = useState<TrainingTab>('heatmap');
 
   useEffect(() => {
@@ -194,12 +212,16 @@ export default function FitnessDashboard() {
       fetch('/api/fitness/activities').then((r) => r.json()),
       fetch('/api/fitness/sleep').then((r) => r.json()),
       fetch('/api/fitness/stress-data').then((r) => r.json()),
+      fetch('/api/fitness/whoop').then((r) => r.json()),
     ])
-      .then(([activityData, sleepData, stressData]) => {
+      .then(([activityData, sleepData, stressData, whoopData]) => {
         setActivities(activityData as FitnessActivity[]);
         setSleepRecords(sleepData.sleep ?? []);
         setRecoveryRecords(sleepData.recovery ?? []);
         setStressRecords(stressData as StressDayRecord[]);
+        setWhoopRecovery(whoopData.recovery ?? []);
+        setWhoopSleep(whoopData.sleep ?? []);
+        setWhoopCycles(whoopData.cycles ?? []);
         setLoading(false);
       })
       .catch(() => setLoading(false));
@@ -271,6 +293,9 @@ export default function FitnessDashboard() {
             <PillButton active={source === 'garmin'} onClick={() => setSource('garmin')} activeClass="bg-blue-900 border-blue-700 text-blue-300">
               Garmin
             </PillButton>
+            <PillButton active={source === 'whoop'} onClick={() => setSource('whoop')} activeClass="bg-purple-900 border-purple-700 text-purple-300">
+              WHOOP
+            </PillButton>
           </div>
           <div className="h-4 w-px bg-gray-6" />
           <div className="flex overflow-hidden rounded-md border border-gray-6">
@@ -331,36 +356,117 @@ export default function FitnessDashboard() {
 
       {/* ── Recovery ── */}
       <div className="flex flex-col gap-3">
-        <SectionGroup
-          label="Recovery"
-          tabs={[
-            { key: 'sleep' as RecoveryTab, label: 'Sleep & Recovery' },
-            { key: 'stress' as RecoveryTab, label: 'Stress' },
-            { key: 'trends' as RecoveryTab, label: 'Trends' },
-          ]}
-          active={recoveryTab}
-          onChange={setRecoveryTab}
-        />
-        {recoveryTab === 'sleep' && (
-          <FitnessSleep sleep={sleepRecords} recovery={recoveryRecords} activities={filtered} unit={unit} />
+        {/* Parent source selector: Garmin and WHOOP are co-equal data sources */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-widest text-gray-10">Recovery</span>
+          <div className="flex overflow-hidden rounded-md border border-gray-6">
+            <button
+              onClick={() => setRecoverySource('garmin')}
+              className={clsx(
+                'px-4 py-1 text-xs font-semibold transition-colors',
+                recoverySource === 'garmin' ? 'bg-blue-900 text-blue-300' : 'text-gray-11 hover:bg-gray-3',
+              )}
+            >
+              Garmin
+            </button>
+            <button
+              onClick={() => setRecoverySource('whoop')}
+              className={clsx(
+                'px-4 py-1 text-xs font-semibold transition-colors',
+                recoverySource === 'whoop' ? 'bg-purple-900 text-purple-300' : 'text-gray-11 hover:bg-gray-3',
+              )}
+            >
+              WHOOP
+            </button>
+          </div>
+        </div>
+
+        {recoverySource === 'garmin' && (
+          <>
+            <SectionGroup
+              label=""
+              tabs={[
+                { key: 'sleep' as GarminRecoveryTab, label: 'Sleep & Recovery' },
+                { key: 'stress' as GarminRecoveryTab, label: 'Stress' },
+                { key: 'trends' as GarminRecoveryTab, label: 'Trends' },
+              ]}
+              active={garminTab}
+              onChange={setGarminTab}
+            />
+            {garminTab === 'sleep' && (
+              <FitnessSleep sleep={sleepRecords} recovery={recoveryRecords} activities={filtered} unit={unit} />
+            )}
+            {garminTab === 'stress' && (
+              <SectionCard
+                title="Stress Heatmap"
+                description="Daily avg stress · year to date"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>}
+              >
+                <FitnessStressHeatmap records={stressRecords} />
+              </SectionCard>
+            )}
+            {garminTab === 'trends' && (
+              <SectionCard
+                title="Recovery Trends"
+                description="7-day rolling averages · sleep, stress, HRV"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18" /><polyline points="17 6 23 6 23 12" /></svg>}
+              >
+                <FitnessTrends sleep={sleepRecords} recovery={recoveryRecords} />
+              </SectionCard>
+            )}
+          </>
         )}
-        {recoveryTab === 'stress' && (
-          <SectionCard
-            title="Stress Heatmap"
-            description="Daily avg stress · year to date"
-            symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>}
-          >
-            <FitnessStressHeatmap records={stressRecords} />
-          </SectionCard>
-        )}
-        {recoveryTab === 'trends' && (
-          <SectionCard
-            title="Recovery Trends"
-            description="7-day rolling averages · sleep, stress, HRV"
-            symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18" /><polyline points="17 6 23 6 23 12" /></svg>}
-          >
-            <FitnessTrends sleep={sleepRecords} recovery={recoveryRecords} />
-          </SectionCard>
+
+        {recoverySource === 'whoop' && (
+          <>
+            <SectionGroup
+              label=""
+              tabs={[
+                { key: 'recovery' as WhoopRecoveryTab, label: 'Recovery' },
+                { key: 'sleep' as WhoopRecoveryTab, label: 'Sleep' },
+                { key: 'strain' as WhoopRecoveryTab, label: 'Strain' },
+                { key: 'trends' as WhoopRecoveryTab, label: 'Trends' },
+              ]}
+              active={whoopTab}
+              onChange={setWhoopTab}
+            />
+            {whoopTab === 'recovery' && (
+              <SectionCard
+                title="WHOOP Recovery"
+                description="Daily recovery score, HRV, resting HR"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>}
+              >
+                <WhoopRecoveryView recovery={whoopRecovery} cycles={whoopCycles} />
+              </SectionCard>
+            )}
+            {whoopTab === 'sleep' && (
+              <SectionCard
+                title="WHOOP Sleep"
+                description="Performance, stages, and respiratory rate"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><path d="M2 12a10 10 0 1 0 10-10 8 8 0 0 1-10 10z" /></svg>}
+              >
+                <WhoopSleepView sleep={whoopSleep} />
+              </SectionCard>
+            )}
+            {whoopTab === 'strain' && (
+              <SectionCard
+                title="WHOOP Strain"
+                description="Daily strain, energy, and heart rate"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>}
+              >
+                <WhoopStrainView cycles={whoopCycles} recovery={whoopRecovery} />
+              </SectionCard>
+            )}
+            {whoopTab === 'trends' && (
+              <SectionCard
+                title="WHOOP Trends"
+                description="7-day rolling averages · recovery, sleep, strain"
+                symbol={<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="h-4 w-4"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18" /><polyline points="17 6 23 6 23 12" /></svg>}
+              >
+                <WhoopTrendsView recovery={whoopRecovery} sleep={whoopSleep} cycles={whoopCycles} />
+              </SectionCard>
+            )}
+          </>
         )}
       </div>
 

--- a/components/pages/fitness/fitness-whoop-calendar.tsx
+++ b/components/pages/fitness/fitness-whoop-calendar.tsx
@@ -1,0 +1,171 @@
+import {
+  Fragment,
+  type FC,
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useMemo,
+} from 'react';
+
+import { TooltipWithBounds, useTooltip, useTooltipInPortal } from '@visx/tooltip';
+
+const SQUARE_SIZE = 12;
+const GAP = 2;
+
+type Cell = { date: string; value: number } | null | undefined;
+
+export type TooltipRow = { label: string; value: string; color?: string };
+
+/**
+ * Shared GitHub-style calendar heatmap for WHOOP metrics. Cells are coloured
+ * by `colorFor(value)`; days with no reading render as empty outlines. Mirrors
+ * the grid maths used by the Garmin stress/sleep heatmaps.
+ */
+const FitnessWhoopCalendar: FC<{
+  valueByDate: Record<string, number>;
+  colorFor: (value: number) => string;
+  avgText: (avg: number | null) => string;
+  tooltipRows: (date: string) => TooltipRow[];
+  legend: ReactNode;
+}> = ({ valueByDate, colorFor, avgText, tooltipRows, legend }) => {
+  const year = new Date().getFullYear();
+
+  const { containerRef, containerBounds } = useTooltipInPortal({ scroll: true, detectBounds: true });
+  const { showTooltip, hideTooltip, tooltipOpen, tooltipLeft, tooltipTop, tooltipData } =
+    useTooltip<string>({ tooltipOpen: false });
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<SVGSVGElement>) => {
+      const tLeft = ('clientX' in event ? event.clientX : 0) - containerBounds.left;
+      const tTop = ('clientY' in event ? event.clientY : 0) - containerBounds.top;
+      const target = event.target as SVGPathElement;
+      const dataDate = target.getAttribute('data-date') ?? undefined;
+      if (dataDate === undefined) return;
+      showTooltip({ tooltipLeft: tLeft, tooltipTop: tTop, tooltipData: dataDate });
+    },
+    [containerBounds.left, containerBounds.top, showTooltip],
+  );
+
+  const firstDay = useMemo(() => new Date(Date.UTC(year, 0, 1)), [year]);
+  const dayOffset = useMemo(() => firstDay.getUTCDay(), [firstDay]);
+
+  const grid = useMemo(() => {
+    const rows: Cell[][] = Array(7)
+      .fill(null)
+      .map(() => new Array(53).fill(null));
+    const date = new Date(Date.UTC(year, 0, 1));
+    const daysInYear = year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0) ? 366 : 365;
+    for (let i = 0; i < daysInYear; i++) {
+      const dow = date.getUTCDay();
+      const col = Math.floor(i / 7) + (date.getUTCDay() < dayOffset ? 1 : 0);
+      const key = date.toISOString().slice(0, 10);
+      const value = valueByDate[key];
+      rows[dow][col] = { date: key, value: value ?? -1 };
+      date.setUTCDate(date.getUTCDate() + 1);
+    }
+    return rows;
+  }, [year, dayOffset, valueByDate]);
+
+  const avg = useMemo(() => {
+    const vals = Object.values(valueByDate);
+    return vals.length ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+  }, [valueByDate]);
+
+  const svgWidth = 53 * SQUARE_SIZE + 52 * GAP;
+  const svgHeight = 7 * SQUARE_SIZE + 6 * GAP + 16;
+
+  return (
+    <div className="flex flex-col p-4">
+      <div className="font-medium">
+        <span className="text-gray-12">{avgText(avg)}</span>
+      </div>
+
+      <div className="relative mt-3">
+        <div className="hide-scrollbar overflow-x-auto">
+          <svg
+            width={svgWidth}
+            height={svgHeight}
+            viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+            xmlns="http://www.w3.org/2000/svg"
+            ref={containerRef}
+            onPointerMove={handlePointerMove}
+            onMouseLeave={hideTooltip}
+          >
+            {Array(12)
+              .fill(null)
+              .map((_, month) => {
+                const firstDayOfMonth = new Date(Date.UTC(year, month, 1));
+                const col = Math.ceil(
+                  (86_400 * dayOffset + firstDayOfMonth.getTime() - firstDay.getTime()) /
+                    604_800_000,
+                );
+                return (
+                  <text
+                    key={month}
+                    x={(SQUARE_SIZE + GAP) * col}
+                    y={12}
+                    fontSize={12}
+                    className="fill-gray-11"
+                  >
+                    {firstDayOfMonth.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })}
+                  </text>
+                );
+              })}
+
+            {grid.map((row, y) => (
+              <Fragment key={y}>
+                {row.map((day, x) => {
+                  if (day === null) return null;
+                  const pathD = `M${(SQUARE_SIZE + GAP) * x + 2} ${(SQUARE_SIZE + GAP) * y + 0.5 + 16}h${SQUARE_SIZE - 4}q1.5 0 1.5 1.5v${SQUARE_SIZE - 4}q0 1.5-1.5 1.5h-${SQUARE_SIZE - 4}q-1.5 0-1.5-1.5v-${SQUARE_SIZE - 4}q0-1.5 1.5-1.5z`;
+
+                  if (day === undefined || day.value < 0) {
+                    return <path key={`c-${x}-${y}`} d={pathD} className="fill-transparent stroke-gray-7" />;
+                  }
+
+                  return (
+                    <path
+                      key={`c-${x}-${y}`}
+                      d={pathD}
+                      className="stroke-gray-7 transition-colors hover:stroke-gray-9"
+                      fill={colorFor(day.value)}
+                      data-date={day.date}
+                    />
+                  );
+                })}
+              </Fragment>
+            ))}
+          </svg>
+        </div>
+
+        {tooltipOpen && tooltipLeft !== undefined && tooltipTop !== undefined && tooltipData !== undefined && (
+          <TooltipWithBounds
+            key={Math.random()}
+            top={tooltipTop}
+            left={tooltipLeft}
+            offsetLeft={-SQUARE_SIZE}
+            className="pointer-events-none absolute left-0 top-0 z-50 rounded border border-gray-6 bg-gray-3 px-2 py-1 text-sm text-gray-12 shadow-md"
+            style={{}}
+          >
+            <div className="flex flex-col gap-0.5">
+              <div className="font-medium text-gray-12">
+                {new Date(tooltipData).toLocaleDateString('en-US', {
+                  day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC',
+                })}
+              </div>
+              {tooltipRows(tooltipData).map((row) => (
+                <div key={row.label} className="flex items-center gap-1 text-gray-11">
+                  <span className="w-20 text-xs">{row.label}</span>
+                  <span className="font-medium" style={row.color ? { color: row.color } : undefined}>{row.value}</span>
+                </div>
+              ))}
+            </div>
+          </TooltipWithBounds>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-end gap-3 text-xs text-gray-11">{legend}</div>
+    </div>
+  );
+};
+
+export default FitnessWhoopCalendar;

--- a/components/pages/fitness/fitness-whoop-heatmap.tsx
+++ b/components/pages/fitness/fitness-whoop-heatmap.tsx
@@ -1,0 +1,57 @@
+import { type FC, useMemo } from 'react';
+
+import FitnessWhoopCalendar, { type TooltipRow } from './fitness-whoop-calendar';
+import type { FitnessWhoopRecovery, FitnessWhoopCycle } from '@/pages/fitness';
+
+// WHOOP's recovery colour bands: red < 34, yellow 34–66, green ≥ 67.
+function bandColor(score: number): string {
+  if (score >= 67) return '#16a34a';
+  if (score >= 34) return '#eab308';
+  return '#ef4444';
+}
+
+const FitnessWhoopHeatmap: FC<{
+  recovery: FitnessWhoopRecovery[];
+  cycles: FitnessWhoopCycle[];
+}> = ({ recovery, cycles }) => {
+  const valueByDate = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const r of recovery) if (r.recovery_score != null) map[r.date] = r.recovery_score;
+    return map;
+  }, [recovery]);
+
+  const recoveryByDate = useMemo(() => new Map(recovery.map((r) => [r.date, r])), [recovery]);
+  const strainByDate = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const c of cycles) if (c.strain != null) map[c.date] = c.strain;
+    return map;
+  }, [cycles]);
+
+  const tooltipRows = (date: string): TooltipRow[] => {
+    const rec = recoveryByDate.get(date);
+    const rows: TooltipRow[] = [];
+    if (rec?.recovery_score != null) rows.push({ label: 'Recovery', value: `${Math.round(rec.recovery_score)}%`, color: bandColor(rec.recovery_score) });
+    if (rec?.hrv_rmssd_milli != null) rows.push({ label: 'HRV', value: `${Math.round(rec.hrv_rmssd_milli)} ms` });
+    if (rec?.resting_heart_rate != null) rows.push({ label: 'Resting HR', value: `${Math.round(rec.resting_heart_rate)} bpm` });
+    if (strainByDate[date] != null) rows.push({ label: 'Day strain', value: strainByDate[date].toFixed(1) });
+    return rows;
+  };
+
+  return (
+    <FitnessWhoopCalendar
+      valueByDate={valueByDate}
+      colorFor={bandColor}
+      avgText={(avg) => (avg == null ? 'No recovery data' : `${Math.round(avg)}% avg recovery in ${new Date().getFullYear()}`)}
+      tooltipRows={tooltipRows}
+      legend={
+        <>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#ef4444' }} />0–33</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#eab308' }} />34–66</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#16a34a' }} />67–100</span>
+        </>
+      }
+    />
+  );
+};
+
+export default FitnessWhoopHeatmap;

--- a/components/pages/fitness/fitness-whoop-recovery.tsx
+++ b/components/pages/fitness/fitness-whoop-recovery.tsx
@@ -1,0 +1,68 @@
+import FitnessWhoopHeatmap from './fitness-whoop-heatmap';
+import type { FitnessWhoopRecovery, FitnessWhoopCycle } from '@/pages/fitness';
+
+// WHOOP's recovery colour bands: red < 34, yellow 34–66, green ≥ 67.
+function recoveryColor(score: number | null | undefined): string {
+  if (score == null) return 'var(--gray-12)';
+  if (score >= 67) return '#16a34a';
+  if (score >= 34) return '#eab308';
+  return '#ef4444';
+}
+
+function fmt(value: number | null | undefined, digits = 0, unit = ''): string {
+  if (value == null) return '—';
+  return `${value.toFixed(digits)}${unit}`;
+}
+
+function StatCard({ label, value, sub, valueColor }: { label: string; value: string; sub?: string; valueColor?: string }) {
+  return (
+    <div className="flex flex-col justify-between rounded-xl border border-gray-6 bg-gray-2 p-4">
+      <div className="text-xs font-medium uppercase tracking-widest text-gray-11">{label}</div>
+      <div className="mt-2 text-3xl font-semibold text-gray-12" style={valueColor ? { color: valueColor } : undefined}>{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-gray-10">{sub}</div>}
+    </div>
+  );
+}
+
+export default function FitnessWhoopRecovery({
+  recovery,
+  cycles,
+}: {
+  recovery: FitnessWhoopRecovery[];
+  cycles: FitnessWhoopCycle[];
+}) {
+  const latest = recovery[0];
+
+  if (recovery.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-10 text-center">
+        <p className="text-sm text-gray-11">No WHOOP recovery data yet.</p>
+        <p className="text-xs text-gray-10">Scores will appear here once the sync worker has pulled from WHOOP.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 p-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          label="Recovery"
+          value={fmt(latest?.recovery_score, 0, '%')}
+          valueColor={recoveryColor(latest?.recovery_score)}
+          sub={latest ? new Date(latest.date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }) : undefined}
+        />
+        <StatCard label="HRV" value={fmt(latest?.hrv_rmssd_milli, 0, ' ms')} sub="rMSSD" />
+        <StatCard label="Resting HR" value={fmt(latest?.resting_heart_rate, 0, ' bpm')} />
+        <StatCard label="SpO₂ / Skin Temp" value={`${fmt(latest?.spo2_percentage, 0, '%')} · ${fmt(latest?.skin_temp_celsius, 1, '°')}`} />
+      </div>
+
+      <div className="rounded-xl border border-gray-6 bg-gray-2">
+        <div className="border-b border-gray-7 px-4 py-3">
+          <div className="text-sm font-medium text-gray-12">Recovery calendar</div>
+          <div className="text-xs text-gray-11">Daily recovery score · this year</div>
+        </div>
+        <FitnessWhoopHeatmap recovery={recovery} cycles={cycles} />
+      </div>
+    </div>
+  );
+}

--- a/components/pages/fitness/fitness-whoop-sleep-heatmap.tsx
+++ b/components/pages/fitness/fitness-whoop-sleep-heatmap.tsx
@@ -1,0 +1,58 @@
+import { type FC, useMemo } from 'react';
+
+import FitnessWhoopCalendar, { type TooltipRow } from './fitness-whoop-calendar';
+import type { FitnessWhoopSleep } from '@/pages/fitness';
+
+// Sleep performance bands: red < 70, yellow 70–84, green ≥ 85.
+function bandColor(pct: number): string {
+  if (pct >= 85) return '#16a34a';
+  if (pct >= 70) return '#eab308';
+  return '#ef4444';
+}
+
+function fmtHm(minutes: number | null | undefined): string {
+  if (minutes == null) return '—';
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+const FitnessWhoopSleepHeatmap: FC<{ sleep: FitnessWhoopSleep[] }> = ({ sleep }) => {
+  const nonNap = useMemo(() => sleep.filter((s) => !s.nap), [sleep]);
+
+  const valueByDate = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const s of nonNap) if (s.sleep_performance_percentage != null) map[s.date] = s.sleep_performance_percentage;
+    return map;
+  }, [nonNap]);
+
+  const sleepByDate = useMemo(() => new Map(nonNap.map((s) => [s.date, s])), [nonNap]);
+
+  const tooltipRows = (date: string): TooltipRow[] => {
+    const s = sleepByDate.get(date);
+    const rows: TooltipRow[] = [];
+    if (s?.sleep_performance_percentage != null) rows.push({ label: 'Performance', value: `${Math.round(s.sleep_performance_percentage)}%`, color: bandColor(s.sleep_performance_percentage) });
+    if (s?.sleep_efficiency_percentage != null) rows.push({ label: 'Efficiency', value: `${Math.round(s.sleep_efficiency_percentage)}%` });
+    if (s?.in_bed_minutes != null && s?.awake_minutes != null) rows.push({ label: 'Asleep', value: fmtHm(s.in_bed_minutes - s.awake_minutes) });
+    if (s?.respiratory_rate != null) rows.push({ label: 'Respiratory', value: s.respiratory_rate.toFixed(1) });
+    return rows;
+  };
+
+  return (
+    <FitnessWhoopCalendar
+      valueByDate={valueByDate}
+      colorFor={bandColor}
+      avgText={(avg) => (avg == null ? 'No sleep data' : `${Math.round(avg)}% avg sleep performance in ${new Date().getFullYear()}`)}
+      tooltipRows={tooltipRows}
+      legend={
+        <>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#ef4444' }} />0–69</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#eab308' }} />70–84</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#16a34a' }} />85–100</span>
+        </>
+      }
+    />
+  );
+};
+
+export default FitnessWhoopSleepHeatmap;

--- a/components/pages/fitness/fitness-whoop-sleep.tsx
+++ b/components/pages/fitness/fitness-whoop-sleep.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import FitnessWhoopSleepHeatmap from './fitness-whoop-sleep-heatmap';
+import type { FitnessWhoopSleep } from '@/pages/fitness';
+
+const STAGES = [
+  { key: 'slow_wave_minutes', label: 'Deep (SWS)', color: '#4f46e5' },
+  { key: 'rem_minutes', label: 'REM', color: '#0090FF' },
+  { key: 'light_minutes', label: 'Light', color: '#38bdf8' },
+  { key: 'awake_minutes', label: 'Awake', color: '#6b7280' },
+] as const;
+
+function fmt(value: number | null | undefined, digits = 0, unit = ''): string {
+  if (value == null) return '—';
+  return `${value.toFixed(digits)}${unit}`;
+}
+
+function fmtHm(minutes: number | null | undefined): string {
+  if (minutes == null) return '—';
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="flex flex-col justify-between rounded-xl border border-gray-6 bg-gray-2 p-4">
+      <div className="text-xs font-medium uppercase tracking-widest text-gray-11">{label}</div>
+      <div className="mt-2 text-3xl font-semibold text-gray-12">{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-gray-10">{sub}</div>}
+    </div>
+  );
+}
+
+function StageTip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded border border-gray-6 bg-gray-2 px-3 py-2 text-xs shadow-md">
+      <div className="mb-1.5 font-medium text-gray-12">{label}</div>
+      {[...payload].reverse().map((p: any) => {
+        const stage = STAGES.find((s) => s.key === p.dataKey);
+        if (!stage || !p.value) return null;
+        return (
+          <div key={p.dataKey} className="flex items-center gap-2 text-gray-11">
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: stage.color }} />
+            <span className="flex-1">{stage.label}</span>
+            <span className="ml-3 font-medium tabular-nums text-gray-12">{fmtHm(p.value)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function FitnessWhoopSleep({ sleep }: { sleep: FitnessWhoopSleep[] }) {
+  const [days, setDays] = useState<14 | 30>(14);
+
+  const nonNap = useMemo(() => sleep.filter((s) => !s.nap), [sleep]);
+  const latest = nonNap[0];
+
+  // Total asleep = in bed − awake (stage minutes for the latest night).
+  const latestAsleep =
+    latest?.in_bed_minutes != null && latest?.awake_minutes != null
+      ? latest.in_bed_minutes - latest.awake_minutes
+      : null;
+
+  const chartData = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    return nonNap
+      .filter((s) => new Date(s.date) >= cutoff)
+      .slice()
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((s) => ({
+        label: new Date(s.date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }),
+        slow_wave_minutes: s.slow_wave_minutes ?? 0,
+        rem_minutes: s.rem_minutes ?? 0,
+        light_minutes: s.light_minutes ?? 0,
+        awake_minutes: s.awake_minutes ?? 0,
+      }));
+  }, [nonNap, days]);
+
+  if (nonNap.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-10 text-center">
+        <p className="text-sm text-gray-11">No WHOOP sleep data yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 p-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          label="Performance"
+          value={fmt(latest?.sleep_performance_percentage, 0, '%')}
+          sub={latest ? new Date(latest.date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }) : undefined}
+        />
+        <StatCard label="Efficiency" value={fmt(latest?.sleep_efficiency_percentage, 0, '%')} />
+        <StatCard label="Consistency" value={fmt(latest?.sleep_consistency_percentage, 0, '%')} />
+        <StatCard label="Time Asleep" value={fmtHm(latestAsleep)} sub={`in bed ${fmtHm(latest?.in_bed_minutes)}`} />
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="REM" value={fmtHm(latest?.rem_minutes)} />
+        <StatCard label="Deep (SWS)" value={fmtHm(latest?.slow_wave_minutes)} />
+        <StatCard label="Light" value={fmtHm(latest?.light_minutes)} />
+        <StatCard label="Respiratory Rate" value={fmt(latest?.respiratory_rate, 1)} sub="breaths/min" />
+      </div>
+
+      <div className="rounded-xl border border-gray-6 bg-gray-2">
+        <div className="border-b border-gray-7 px-4 py-3">
+          <div className="text-sm font-medium text-gray-12">Sleep performance calendar</div>
+          <div className="text-xs text-gray-11">Nightly sleep performance · this year</div>
+        </div>
+        <FitnessWhoopSleepHeatmap sleep={sleep} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-11">Sleep stages per night</p>
+        <div className="flex overflow-hidden rounded-md border border-gray-6">
+          {([14, 30] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              className={clsx(
+                'px-3 py-1 text-xs font-medium transition-colors',
+                days === d ? 'bg-gray-4 text-gray-12' : 'text-gray-11 hover:bg-gray-3',
+              )}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: -16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--gray-5)" vertical={false} />
+          <XAxis dataKey="label" tick={{ fontSize: 11, fill: 'var(--gray-11)' }} tickLine={false} axisLine={false} />
+          <YAxis
+            tick={{ fontSize: 11, fill: 'var(--gray-11)' }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) => `${Math.round(v / 60)}h`}
+          />
+          <Tooltip content={<StageTip />} cursor={{ fill: 'var(--gray-4)' }} />
+          {STAGES.map((s) => (
+            <Bar key={s.key} dataKey={s.key} stackId="sleep" fill={s.color} radius={s.key === 'slow_wave_minutes' ? [0, 0, 3, 3] : undefined} />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+        {STAGES.map((s) => (
+          <span key={s.key} className="flex items-center gap-1.5 text-xs text-gray-11">
+            <span className="h-2 w-2 rounded-full" style={{ background: s.color }} />
+            {s.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/pages/fitness/fitness-whoop-strain-heatmap.tsx
+++ b/components/pages/fitness/fitness-whoop-strain-heatmap.tsx
@@ -1,0 +1,50 @@
+import { type FC, useMemo } from 'react';
+
+import FitnessWhoopCalendar, { type TooltipRow } from './fitness-whoop-calendar';
+import type { FitnessWhoopCycle } from '@/pages/fitness';
+
+// WHOOP strain zones: light (0–9), moderate (10–13), strenuous (14–17), all-out (18–21).
+function zoneColor(strain: number): string {
+  if (strain >= 18) return '#ef4444';
+  if (strain >= 14) return '#f97316';
+  if (strain >= 10) return '#a855f7';
+  return '#6366f1';
+}
+
+const FitnessWhoopStrainHeatmap: FC<{ cycles: FitnessWhoopCycle[] }> = ({ cycles }) => {
+  const valueByDate = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const c of cycles) if (c.strain != null) map[c.date] = c.strain;
+    return map;
+  }, [cycles]);
+
+  const cycleByDate = useMemo(() => new Map(cycles.map((c) => [c.date, c])), [cycles]);
+
+  const tooltipRows = (date: string): TooltipRow[] => {
+    const c = cycleByDate.get(date);
+    const rows: TooltipRow[] = [];
+    if (c?.strain != null) rows.push({ label: 'Day strain', value: c.strain.toFixed(1), color: zoneColor(c.strain) });
+    if (c?.kilojoules != null) rows.push({ label: 'Energy', value: `${Math.round(c.kilojoules / 4.184).toLocaleString()} kcal` });
+    if (c?.avg_heart_rate != null) rows.push({ label: 'Avg HR', value: `${Math.round(c.avg_heart_rate)} bpm` });
+    return rows;
+  };
+
+  return (
+    <FitnessWhoopCalendar
+      valueByDate={valueByDate}
+      colorFor={zoneColor}
+      avgText={(avg) => (avg == null ? 'No strain data' : `${avg.toFixed(1)} avg strain in ${new Date().getFullYear()}`)}
+      tooltipRows={tooltipRows}
+      legend={
+        <>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#6366f1' }} />0–9</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#a855f7' }} />10–13</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#f97316' }} />14–17</span>
+          <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm" style={{ background: '#ef4444' }} />18–21</span>
+        </>
+      }
+    />
+  );
+};
+
+export default FitnessWhoopStrainHeatmap;

--- a/components/pages/fitness/fitness-whoop-strain.tsx
+++ b/components/pages/fitness/fitness-whoop-strain.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from 'recharts';
+import FitnessWhoopStrainHeatmap from './fitness-whoop-strain-heatmap';
+import type { FitnessWhoopCycle, FitnessWhoopRecovery } from '@/pages/fitness';
+
+function fmt(value: number | null | undefined, digits = 0, unit = ''): string {
+  if (value == null) return '—';
+  return `${value.toFixed(digits)}${unit}`;
+}
+
+// WHOOP strain zones: light (0–9), moderate (10–13), strenuous (14–17), all-out (18–21).
+function strainColor(strain: number): string {
+  if (strain >= 18) return '#ef4444';
+  if (strain >= 14) return '#f97316';
+  if (strain >= 10) return '#a855f7';
+  return '#6366f1';
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="flex flex-col justify-between rounded-xl border border-gray-6 bg-gray-2 p-4">
+      <div className="text-xs font-medium uppercase tracking-widest text-gray-11">{label}</div>
+      <div className="mt-2 text-3xl font-semibold text-gray-12">{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-gray-10">{sub}</div>}
+    </div>
+  );
+}
+
+function StrainTip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
+  if (!active || !payload?.length) return null;
+  const p = payload[0];
+  if (p.value == null) return null;
+  return (
+    <div className="rounded border border-gray-6 bg-gray-2 px-3 py-2 text-xs shadow-md">
+      <div className="mb-1 font-medium text-gray-12">{label}</div>
+      <div className="flex items-center gap-2 text-gray-11">
+        <span className="h-2 w-2 rounded-full" style={{ background: strainColor(p.value) }} />
+        <span className="flex-1">Day strain</span>
+        <span className="ml-3 font-medium tabular-nums text-gray-12">{p.value.toFixed(1)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function FitnessWhoopStrain({
+  cycles,
+  recovery,
+}: {
+  cycles: FitnessWhoopCycle[];
+  recovery: FitnessWhoopRecovery[];
+}) {
+  const [days, setDays] = useState<14 | 30>(14);
+
+  const latest = cycles[0];
+
+  // WHOOP reports energy in kilojoules; dietary calories ≈ kJ / 4.184.
+  const latestCalories = latest?.kilojoules != null ? latest.kilojoules / 4.184 : null;
+
+  const avgStrain = useMemo(() => {
+    const vals = cycles.map((c) => c.strain).filter((v): v is number => v != null);
+    return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
+  }, [cycles]);
+
+  const chartData = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    return cycles
+      .filter((c) => new Date(c.date) >= cutoff)
+      .slice()
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((c) => ({
+        label: new Date(c.date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }),
+        strain: c.strain ?? 0,
+      }));
+  }, [cycles, days]);
+
+  if (cycles.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-10 text-center">
+        <p className="text-sm text-gray-11">No WHOOP strain data yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 p-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          label="Day Strain"
+          value={fmt(latest?.strain, 1)}
+          sub={latest ? new Date(latest.date + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }) : undefined}
+        />
+        <StatCard label="Avg Strain" value={fmt(avgStrain, 1)} sub={`${cycles.length}-day`} />
+        <StatCard label="Energy" value={latestCalories != null ? `${(latestCalories / 1000).toFixed(1)}k` : '—'} sub="kcal" />
+        <StatCard label="Avg / Max HR" value={`${fmt(latest?.avg_heart_rate)} / ${fmt(latest?.max_heart_rate)}`} sub="bpm" />
+      </div>
+
+      <div className="rounded-xl border border-gray-6 bg-gray-2">
+        <div className="border-b border-gray-7 px-4 py-3">
+          <div className="text-sm font-medium text-gray-12">Strain calendar</div>
+          <div className="text-xs text-gray-11">Daily strain load · this year</div>
+        </div>
+        <FitnessWhoopStrainHeatmap cycles={cycles} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-11">Day strain (0–21)</p>
+        <div className="flex overflow-hidden rounded-md border border-gray-6">
+          {([14, 30] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              className={clsx(
+                'px-3 py-1 text-xs font-medium transition-colors',
+                days === d ? 'bg-gray-4 text-gray-12' : 'text-gray-11 hover:bg-gray-3',
+              )}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: -16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--gray-5)" vertical={false} />
+          <XAxis dataKey="label" tick={{ fontSize: 11, fill: 'var(--gray-11)' }} tickLine={false} axisLine={false} />
+          <YAxis tick={{ fontSize: 11, fill: 'var(--gray-11)' }} tickLine={false} axisLine={false} domain={[0, 21]} />
+          <Tooltip content={<StrainTip />} cursor={{ fill: 'var(--gray-4)' }} />
+          <Bar dataKey="strain" radius={[3, 3, 0, 0]}>
+            {chartData.map((d, i) => (
+              <Cell key={i} fill={strainColor(d.strain)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+        <span className="flex items-center gap-1.5 text-xs text-gray-11"><span className="h-2 w-2 rounded-full" style={{ background: '#6366f1' }} />Light 0–9</span>
+        <span className="flex items-center gap-1.5 text-xs text-gray-11"><span className="h-2 w-2 rounded-full" style={{ background: '#a855f7' }} />Moderate 10–13</span>
+        <span className="flex items-center gap-1.5 text-xs text-gray-11"><span className="h-2 w-2 rounded-full" style={{ background: '#f97316' }} />Strenuous 14–17</span>
+        <span className="flex items-center gap-1.5 text-xs text-gray-11"><span className="h-2 w-2 rounded-full" style={{ background: '#ef4444' }} />All-out 18–21</span>
+      </div>
+    </div>
+  );
+}

--- a/components/pages/fitness/fitness-whoop-trends.tsx
+++ b/components/pages/fitness/fitness-whoop-trends.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import type {
+  FitnessWhoopRecovery,
+  FitnessWhoopSleep,
+  FitnessWhoopCycle,
+} from '@/pages/fitness';
+
+type MetricKey = 'recovery' | 'sleep_performance' | 'hrv' | 'resting_hr' | 'respiratory_rate' | 'strain';
+
+const METRICS: Record<MetricKey, { label: string; color: string; unit: string; hint: string; axis: 'left' | 'right' }> = {
+  recovery:          { label: 'Recovery',        color: '#16a34a', unit: '%',   hint: '0–100, higher is better',   axis: 'left' },
+  sleep_performance: { label: 'Sleep Perf.',      color: '#0090FF', unit: '%',   hint: '% of sleep need met',        axis: 'left' },
+  hrv:               { label: 'HRV',             color: '#22c55e', unit: ' ms', hint: 'rMSSD, higher is better',    axis: 'left' },
+  resting_hr:        { label: 'Resting HR',       color: '#f43f5e', unit: ' bpm',hint: 'lower is better',            axis: 'left' },
+  respiratory_rate:  { label: 'Respiratory',      color: '#06b6d4', unit: ' rpm',hint: 'breaths/min during sleep',   axis: 'left' },
+  strain:            { label: 'Day Strain',       color: '#a855f7', unit: '',    hint: '0–21 scale',                 axis: 'right' },
+};
+
+const METRIC_ORDER: MetricKey[] = ['recovery', 'sleep_performance', 'hrv', 'resting_hr', 'respiratory_rate', 'strain'];
+const DEFAULT_ACTIVE = new Set<MetricKey>(['recovery', 'sleep_performance', 'strain']);
+
+function rollingAvg(points: { date: string; value: number | null }[], window: number): Map<string, number | null> {
+  const out = new Map<string, number | null>();
+  for (let i = 0; i < points.length; i++) {
+    const slice = points
+      .slice(Math.max(0, i - window + 1), i + 1)
+      .map((p) => p.value)
+      .filter((v): v is number => v !== null);
+    out.set(points[i].date, slice.length > 0 ? slice.reduce((a, b) => a + b, 0) / slice.length : null);
+  }
+  return out;
+}
+
+function ChartTip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
+  if (!active || !payload?.length) return null;
+  const visible = payload.filter((p: any) => p.value !== null && p.value !== undefined);
+  if (!visible.length) return null;
+  return (
+    <div className="rounded border border-gray-6 bg-gray-2 px-3 py-2 text-xs shadow-md">
+      <div className="mb-1.5 font-medium text-gray-12">{label}</div>
+      {visible.map((p: any) => {
+        const meta = METRICS[p.dataKey as MetricKey];
+        return (
+          <div key={p.dataKey} className="flex items-center gap-2 text-gray-11">
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: p.color }} />
+            <span className="flex-1">{meta?.label ?? p.dataKey}</span>
+            <span className="ml-3 font-medium tabular-nums text-gray-12">
+              {meta?.axis === 'right' ? p.value.toFixed(1) : Math.round(p.value)}{meta?.unit ?? ''}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function FitnessWhoopTrends({
+  recovery,
+  sleep,
+  cycles,
+}: {
+  recovery: FitnessWhoopRecovery[];
+  sleep: FitnessWhoopSleep[];
+  cycles: FitnessWhoopCycle[];
+}) {
+  const [days, setDays] = useState<90 | 180>(90);
+  const [active, setActive] = useState<Set<MetricKey>>(DEFAULT_ACTIVE);
+  const WINDOW = 7;
+
+  const toggle = (key: MetricKey) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        if (next.size === 1) return prev; // keep at least one
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const data = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    cutoff.setHours(0, 0, 0, 0);
+
+    const nonNap = sleep.filter((s) => !s.nap);
+    const recoveryMap = new Map(recovery.map((r) => [r.date, r.recovery_score]));
+    const sleepPerfMap = new Map(nonNap.map((s) => [s.date, s.sleep_performance_percentage]));
+    const hrvMap = new Map(recovery.map((r) => [r.date, r.hrv_rmssd_milli]));
+    const hrMap = new Map(recovery.map((r) => [r.date, r.resting_heart_rate]));
+    const respMap = new Map(nonNap.map((s) => [s.date, s.respiratory_rate]));
+    const strainMap = new Map(cycles.map((c) => [c.date, c.strain]));
+
+    const allDates = Array.from(
+      new Set([
+        ...Array.from(recoveryMap.keys()),
+        ...Array.from(sleepPerfMap.keys()),
+        ...Array.from(strainMap.keys()),
+      ]),
+    ).sort().filter((d) => new Date(d) >= cutoff);
+
+    const avgs = {
+      recovery:          rollingAvg(allDates.map((d) => ({ date: d, value: recoveryMap.get(d)  ?? null })), WINDOW),
+      sleep_performance: rollingAvg(allDates.map((d) => ({ date: d, value: sleepPerfMap.get(d) ?? null })), WINDOW),
+      hrv:               rollingAvg(allDates.map((d) => ({ date: d, value: hrvMap.get(d)        ?? null })), WINDOW),
+      resting_hr:        rollingAvg(allDates.map((d) => ({ date: d, value: hrMap.get(d)         ?? null })), WINDOW),
+      respiratory_rate:  rollingAvg(allDates.map((d) => ({ date: d, value: respMap.get(d)       ?? null })), WINDOW),
+      strain:            rollingAvg(allDates.map((d) => ({ date: d, value: strainMap.get(d)     ?? null })), WINDOW),
+    };
+
+    return allDates.map((d) => ({
+      date: d,
+      label: new Date(d + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }),
+      recovery:          avgs.recovery.get(d)          ?? null,
+      sleep_performance: avgs.sleep_performance.get(d) ?? null,
+      hrv:               avgs.hrv.get(d)               ?? null,
+      resting_hr:        avgs.resting_hr.get(d)        ?? null,
+      respiratory_rate:  avgs.respiratory_rate.get(d)  ?? null,
+      strain:            avgs.strain.get(d)            ?? null,
+    }));
+  }, [recovery, sleep, cycles, days]);
+
+  const xTick = Math.max(1, Math.floor(data.length / 8));
+
+  return (
+    <div className="flex flex-col p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-xs text-gray-11">{WINDOW}-day rolling averages</p>
+        <div className="flex overflow-hidden rounded-md border border-gray-6">
+          {([90, 180] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              className={clsx(
+                'px-3 py-1 text-xs font-medium transition-colors',
+                days === d ? 'bg-gray-4 text-gray-12' : 'text-gray-11 hover:bg-gray-3',
+              )}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {METRIC_ORDER.map((key) => {
+          const { label, color } = METRICS[key];
+          const on = active.has(key);
+          return (
+            <button
+              key={key}
+              onClick={() => toggle(key)}
+              className={clsx(
+                'flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                on ? 'border-gray-6 bg-gray-3 text-gray-12' : 'border-gray-6 text-gray-10 hover:bg-gray-3 hover:text-gray-11',
+              )}
+            >
+              <span className="h-2 w-2 rounded-full transition-opacity" style={{ background: color, opacity: on ? 1 : 0.3 }} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={data} margin={{ top: 4, right: -16, bottom: 0, left: -16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--gray-5)" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 11, fill: 'var(--gray-11)' }}
+            tickLine={false}
+            axisLine={false}
+            interval={xTick}
+          />
+          <YAxis yAxisId="left" tick={{ fontSize: 11, fill: 'var(--gray-11)' }} tickLine={false} axisLine={false} domain={[0, 100]} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11, fill: 'var(--gray-11)' }} tickLine={false} axisLine={false} domain={[0, 21]} />
+          <Tooltip content={<ChartTip />} />
+          {METRIC_ORDER.filter((key) => active.has(key)).map((key) => (
+            <Line
+              key={key}
+              yAxisId={METRICS[key].axis}
+              type="monotone"
+              dataKey={key}
+              stroke={METRICS[key].color}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1">
+        {METRIC_ORDER.filter((key) => active.has(key)).map((key) => {
+          const { label, color, hint } = METRICS[key];
+          return (
+            <span key={key} className="text-xs text-gray-11">
+              <span className="font-medium" style={{ color }}>{label}</span>
+              {' · '}{hint}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/pages/api/fitness/whoop.ts
+++ b/pages/api/fitness/whoop.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import getFitnessSupabase from '@/lib/services/fitness-supabase';
+import type {
+  FitnessWhoopRecovery,
+  FitnessWhoopSleep,
+  FitnessWhoopCycle,
+} from '@/pages/fitness';
+
+interface WhoopResponse {
+  recovery: FitnessWhoopRecovery[];
+  sleep: FitnessWhoopSleep[];
+  cycles: FitnessWhoopCycle[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WhoopResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    const supabase = getFitnessSupabase();
+
+    const [recoveryResult, sleepResult, cyclesResult] = await Promise.all([
+      supabase
+        .from('whoop_recovery')
+        .select('cycle_id, date, recovery_score, resting_heart_rate, hrv_rmssd_milli, spo2_percentage, skin_temp_celsius')
+        .order('date', { ascending: false }),
+      supabase
+        .from('whoop_sleep')
+        .select('sleep_id, date, nap, sleep_performance_percentage, sleep_efficiency_percentage, sleep_consistency_percentage, respiratory_rate, in_bed_minutes, awake_minutes, rem_minutes, slow_wave_minutes, light_minutes')
+        .order('date', { ascending: false }),
+      supabase
+        .from('whoop_cycles')
+        .select('cycle_id, date, strain, kilojoules, avg_heart_rate, max_heart_rate')
+        .order('date', { ascending: false }),
+    ]);
+
+    if (recoveryResult.error) throw recoveryResult.error;
+    if (sleepResult.error) throw sleepResult.error;
+    if (cyclesResult.error) throw cyclesResult.error;
+
+    res.setHeader('cache-control', 'public, s-maxage=3600, stale-while-revalidate=600');
+    res.status(200).json({
+      recovery: (recoveryResult.data as FitnessWhoopRecovery[]) ?? [],
+      sleep: (sleepResult.data as FitnessWhoopSleep[]) ?? [],
+      cycles: (cyclesResult.data as FitnessWhoopCycle[]) ?? [],
+    });
+  } catch (err) {
+    console.error('fitness whoop:', err);
+    res.status(200).json({ recovery: [], sleep: [], cycles: [] });
+  }
+}

--- a/pages/fitness/index.tsx
+++ b/pages/fitness/index.tsx
@@ -33,9 +33,43 @@ export interface FitnessRecoveryRecord {
   recovery_time_hours: number | null;
 }
 
+export interface FitnessWhoopRecovery {
+  cycle_id: string;
+  date: string;
+  recovery_score: number | null;
+  resting_heart_rate: number | null;
+  hrv_rmssd_milli: number | null;
+  spo2_percentage: number | null;
+  skin_temp_celsius: number | null;
+}
+
+export interface FitnessWhoopSleep {
+  sleep_id: string;
+  date: string;
+  nap: boolean | null;
+  sleep_performance_percentage: number | null;
+  sleep_efficiency_percentage: number | null;
+  sleep_consistency_percentage: number | null;
+  respiratory_rate: number | null;
+  in_bed_minutes: number | null;
+  awake_minutes: number | null;
+  rem_minutes: number | null;
+  slow_wave_minutes: number | null;
+  light_minutes: number | null;
+}
+
+export interface FitnessWhoopCycle {
+  cycle_id: string;
+  date: string;
+  strain: number | null;
+  kilojoules: number | null;
+  avg_heart_rate: number | null;
+  max_heart_rate: number | null;
+}
+
 export interface FitnessActivity {
   id: string;
-  source: 'strava' | 'garmin';
+  source: 'strava' | 'garmin' | 'whoop';
   name: string | null;
   sport_type: string | null;
   start_time: string;
@@ -59,7 +93,7 @@ const FitnessPage: NextPage = () => {
             Fitness
           </h1>
           <p className="mt-2 text-gray-11">
-            Training data synced from Strava and Garmin.
+            Training data synced from Strava, Garmin, and WHOOP.
           </p>
         </div>
         <FitnessDashboard />


### PR DESCRIPTION
Surfaces WHOOP recovery, sleep, strain, and workouts on `/fitness`, reading from the `whoop_*` Supabase tables synced by the `strava-garmin-mcp` worker.

## What changed
The Recovery section is restructured so **Garmin** and **WHOOP** are co-equal parent tabs, each with their own child views:
- **Garmin** (unchanged): Sleep & Recovery, Stress, Trends
- **WHOOP**: Recovery, Sleep, Strain, Trends

WHOOP views mirror the Garmin visuals and add what its richer schema exposes:
- **Recovery** — score / HRV / RHR / SpO₂ / skin-temp cards + a recovery calendar heatmap in WHOOP's red/yellow/green bands
- **Sleep** — performance / efficiency / consistency, a stage-breakdown bar chart, and a sleep-performance calendar heatmap
- **Strain** — day strain, energy, HR, a zoned strain bar chart, and a strain calendar heatmap (WHOOP has no stress metric, so strain fills that slot)
- **Trends** — 7-day rolling averages of recovery, sleep performance, HRV, resting HR, respiratory rate, and strain

WHOOP workouts also appear in the shared activity log via a new purple source pill. All three WHOOP heatmaps share one reusable calendar component (`fitness-whoop-calendar.tsx`).

## New files
- `pages/api/fitness/whoop.ts` — API route for the three WHOOP tables
- `components/pages/fitness/fitness-whoop-{recovery,sleep,strain,trends}.tsx` — the child views
- `components/pages/fitness/fitness-whoop-{calendar,heatmap,sleep-heatmap,strain-heatmap}.tsx` — the shared calendar + three heatmaps

## Verification
`tsc --noEmit` passes (incl. the `Map.keys()` iterator fix). Verified in a local dev preview against Supabase: all four WHOOP child tabs render with real data, both new heatmaps show correctly, and the Garmin side is unchanged. Charts look sparse only because there are ~2 days of WHOOP history so far.

## Note
Depends on the WHOOP tables existing in Supabase (added in strava-garmin-mcp PR #2). Those are already live, so this reads real data today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)